### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group=com.enonic.app
 projectName=dictaphone
 appName=com.enonic.app.dictaphone
 xpVersion=8.0.0-B4
-version=1.2.0-B1
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master version from `1.2.0-B1` to `2.0.0-SNAPSHOT` to start the XP 8 line.
- Add `releaseBranch:` block to `enonic-gradle.yml` listing both `master` and `1.x` so the maintenance branch can publish releases.
- Maintenance branch `1.x` was created from tag `v1.2.0-B1` to keep the XP 7 line alive.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `enonic/release-tools/build-and-publish` runs cleanly on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)