### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `releaseBranch:` block to `enonic-gradle.yml` listing both `master` and `1.x`. The `enonic/release-tools/build-and-publish` action reads this config from the workflow file on the branch being pushed, so `1.x` needs its own copy to be classified as a release branch.
- No version bump or other changes — those are master-only per the app-booster reference.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a CI run on `1.x` classifies it as a release branch when an actual version bump is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)