### PR TITLE
Bump enonic libs to XP8 SNAPSHOTs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 task webpack(type: NodeTask) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-mustache = "2.1.1"
-router = "3.2.0"
+mustache = "3.0.0-SNAPSHOT"
+router = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }


### PR DESCRIPTION
## Summary

Bump enonic-lib deps still pinned to pre-XP8 release versions, and flip the repo to `xp.enonicRepo('dev')` so Gradle can resolve the new SNAPSHOTs.

- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT
- `lib-router` 3.2.0 → 4.0.0-SNAPSHOT
- `xp.enonicRepo()` → `xp.enonicRepo('dev')`

## Test plan

- [ ] `./gradlew build --refresh-dependencies` resolves both SNAPSHOTs cleanly and tests pass
- [ ] E2E smoke against XP 8